### PR TITLE
Modifications to support build on Linux Mint 19

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ src/sample.avi
 src/sample/
 src/ut_cmdmap.cpp
 src/_README.txt
+
+# editors
+.*.swp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,6 +32,10 @@ endif ()
 #~ find_package(lo REQUIRED )
 # find OpenCV package
 find_package( OpenCV REQUIRED )
+if( OpenCV_FOUND )
+list( APPEND ThirdParty_LIBS ${OpenCV_LIBS} )
+    include_directories( ${OpenCV_INCLUDE_DIRS} )
+endif( OpenCV_FOUND )
 # add the binary tree to the search path for include files so that we will find main_config.h
 include_directories("${PROJECT_BINARY_DIR}")
 
@@ -51,6 +55,7 @@ add_executable( ${CVOM_BIN_NAME} main_config.hpp ominputdev.hpp footcontroller.c
                   ocv.cpp ocv.hpp cmdmap.hpp osc.cpp osc.hpp midi.cpp midi.hpp main.cpp )
 target_link_libraries( ${CVOM_BIN_NAME} ${OpenCV_LIBS} ) 
 target_link_libraries( ${CVOM_BIN_NAME} ${Boost_LIBRARIES} )
+target_link_libraries( ${CVOM_BIN_NAME} lo v4l2 jack )
  
 
 

--- a/src/ocv.hpp
+++ b/src/ocv.hpp
@@ -30,6 +30,8 @@
 #include "opencv2/imgproc/imgproc.hpp"
 #include "opencv2/core/core.hpp"
 #include <opencv/cv.h>
+#include "opencv2/opencv.hpp"
+
 
 using namespace std;
 using namespace cv;


### PR DESCRIPTION
The upstream was found not to build on Mint 19 - likely due to version
changes of dependencies, as well as differences in build environment.

A small change (an extra include) in ocv.hpp and libraries explicitly
added to the build scripts for linking solved the problem.

**Side note** Whilst the application runs, and hsvfilter.config has been modified and re-modified, I cannot get it to recognise my coloured patch and work the controller :( The debug windows are open, the hsv view shows my target as a white patch, the "+ light -" slider has been slid, but the threshold view remains resolutely black and I have no target marked on the feed window. I'll keep trying as this would be so useful to me.